### PR TITLE
Add next-event predictions to rankings cutoff tables

### DIFF
--- a/src/components/tools/EventRankingsChart.tsx
+++ b/src/components/tools/EventRankingsChart.tsx
@@ -19,7 +19,7 @@ import {
   buildTiers,
   buildChartData,
   buildTrendData,
-  buildNextEventPredictions,
+  buildNextEventPredictionRanges,
 } from '../../lib/eventRankings';
 import type { EventCutoff, EventCutoffsData } from '../../lib/eventRankings';
 
@@ -180,7 +180,7 @@ function RankingSubChart({
   );
 
   const nextEventPredictions = useMemo(
-    () => buildNextEventPredictions(chartData, tiers),
+    () => buildNextEventPredictionRanges(chartData, tiers),
     [chartData, tiers],
   );
 
@@ -325,10 +325,16 @@ function RankingSubChart({
                 Next Event*
               </td>
               {tiers.map(tier => {
-                const predicted = nextEventPredictions[tier.key];
+                const range = nextEventPredictions[tier.key];
                 return (
                   <td key={tier.key} className="text-right py-2 px-3 font-mono tabular-nums text-secondary italic">
-                    {predicted != null ? formatScore(predicted) : <span className="opacity-50">—</span>}
+                    {range != null ? (
+                      <span title={`±1 std dev over ${range.n} events (σ = ${formatScore(range.stdDev)})`}>
+                        {formatScore(range.low)}–{formatScore(range.high)}
+                      </span>
+                    ) : (
+                      <span className="opacity-50">—</span>
+                    )}
                   </td>
                 );
               })}
@@ -338,7 +344,7 @@ function RankingSubChart({
         </table>
       </div>
       <p className="text-xs text-secondary mt-2 leading-relaxed">
-        * Trend-line estimate only — for rough planning reference. Actual cutoffs depend heavily on the strength of the cards being offered that event, which can shift scores significantly above or below this projection.
+        * Predicted range is trend-line ± one standard deviation of historical residuals — for rough planning reference. With a small pool of events, the range may not capture outliers: exceptionally strong or weak reward cards can push actual cutoffs well outside these bounds.
       </p>
     </div>
   );

--- a/src/lib/eventRankings.ts
+++ b/src/lib/eventRankings.ts
@@ -163,3 +163,67 @@ export function buildNextEventPredictions(
   }
   return predictions;
 }
+
+// --- Next-event prediction ranges ---
+
+export interface PredictionRange {
+  predicted: number;
+  low: number;
+  high: number;
+  /** Standard deviation of residuals from the trend line. */
+  stdDev: number;
+  /** Number of historical data points used. */
+  n: number;
+}
+
+/**
+ * Extrapolate the trend line one step ahead and express uncertainty as ±1
+ * standard deviation of the residuals from that trend line (using n−2 degrees
+ * of freedom, which is the standard error for a simple linear regression).
+ *
+ * Returns null for a tier when there are fewer than 3 data points (need at
+ * least n−2 = 1 degree of freedom) or if the predicted value is non-positive.
+ */
+export function buildNextEventPredictionRanges(
+  chartData: Record<string, string | number>[],
+  tiers: Tier[],
+): Record<string, PredictionRange | null> {
+  const nextIdx = chartData.length;
+  const ranges: Record<string, PredictionRange | null> = {};
+
+  for (const tier of tiers) {
+    const points = chartData
+      .map((r, i) => ({ x: i, y: r[tier.key] as number }))
+      .filter(p => p.y != null && !isNaN(p.y));
+
+    const reg = linearRegression(points);
+    if (!reg || points.length < 3) {
+      ranges[tier.key] = null;
+      continue;
+    }
+
+    const predicted = Math.round(reg.slope * nextIdx + reg.intercept);
+    if (predicted <= 0) {
+      ranges[tier.key] = null;
+      continue;
+    }
+
+    // Residual standard deviation (n−2 degrees of freedom for linear regression)
+    const n = points.length;
+    const sumSqResiduals = points.reduce((sum, p) => {
+      const fitted = reg.slope * p.x + reg.intercept;
+      return sum + (p.y - fitted) ** 2;
+    }, 0);
+    const stdDev = Math.sqrt(sumSqResiduals / (n - 2));
+
+    ranges[tier.key] = {
+      predicted,
+      low: Math.max(1, Math.round(predicted - stdDev)),
+      high: Math.round(predicted + stdDev),
+      stdDev: Math.round(stdDev),
+      n,
+    };
+  }
+
+  return ranges;
+}


### PR DESCRIPTION
For each period/event-type combination, a "Next Event*" row now appears
at the bottom of every data table, showing the trend-line extrapolation
one step beyond the most recent event for all rank tiers. A footnote
beneath each table qualifies that these are rough planning estimates
only, and that actual cutoffs depend heavily on the strength of the
cards offered that event.

New utility: buildNextEventPredictions() in eventRankings.ts extrapolates
the least-squares regression one index beyond chartData.length, returning
null for any tier with fewer than 2 data points or a non-positive result.

https://claude.ai/code/session_01VT94JN6P4SdQrvTD6PXHh7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added next event predictions to the ranking chart, displaying predicted cutoff score ranges per tier based on historical trends
  * Shows uncertainty ranges (low–high) with an explanatory footnote detailing the prediction methodology and potential limitations with small event pools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->