### PR TITLE
Update [id].astro

### DIFF
--- a/src/pages/en/cards/[id].astro
+++ b/src/pages/en/cards/[id].astro
@@ -1037,8 +1037,8 @@ const jsonLd = {
                         <div class="text-xs">
                           <div class="flex items-center justify-between gap-2">
                             <span>
-                              Tower Drop
-                              <span class="text-secondary ml-1">(Floors: {drop.floors.join(', ')})</span>
+                              Stage Drop
+                              <span class="text-secondary ml-1">(Stages: {drop.floors.join(', ')})</span>
                             </span>
                             <div class="flex items-center gap-2">
                               <span class="text-secondary" title={`Event #${drop.event_id}`}>


### PR DESCRIPTION
Make text for drop/chapter reward more ambiguous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event card display terminology from "Tower Drop"/"Floors" to "Stage Drop"/"Stages" for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->