### PR TITLE
Feat/spirit scroll theme

### DIFF
--- a/src/components/cards/CardTable.tsx
+++ b/src/components/cards/CardTable.tsx
@@ -948,14 +948,14 @@ export default function CardTable({ initialCards }: CardTableProps) {
               </tr>
             ) : (
               table.getRowModel().rows.map(row => (
-                <tr key={row.id} className="hover:bg-surface transition-colors">
+                <tr key={row.id} className="hover:bg-surface transition-colors" data-attribute={row.original.stats.attribute_name?.toLowerCase()}>
                   {row.getVisibleCells().map(cell => {
                     const meta = cell.column.columnDef.meta as ColumnMeta | undefined;
                     // Skip completely hidden columns
                     if (meta?.hidden) return null;
                     const hideOnSmall = meta?.hideOnSmall;
                     return (
-                      <td key={cell.id} className={hideOnSmall ? 'hidden xl:table-cell' : ''}>
+                      <td key={cell.id} className={hideOnSmall ? 'hidden xl:table-cell' : ''} data-column={cell.column.id}>
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
                       </td>
                     );

--- a/src/components/cards/GameIcon.tsx
+++ b/src/components/cards/GameIcon.tsx
@@ -38,7 +38,7 @@ export function AttributeIcon({
   const iconUrl = getAttributeIconUrl(value, { width: sizeConfig.width * 2 }); // 2x for retina
 
   return (
-    <span className={`inline-flex items-center gap-1 ${className}`} title={value}>
+    <span className={`game-icon inline-flex items-center gap-1 ${className}`} title={value}>
       <img
         src={iconUrl}
         alt={value}
@@ -61,7 +61,7 @@ export function TypeIcon({
   const iconUrl = getTypeIconUrl(value, { width: sizeConfig.width * 2 }); // 2x for retina
 
   return (
-    <span className={`inline-flex items-center gap-1 ${className}`} title={value}>
+    <span className={`game-icon inline-flex items-center gap-1 ${className}`} title={value}>
       <img
         src={iconUrl}
         alt={value}

--- a/src/components/cards/cardTableColumns.tsx
+++ b/src/components/cards/cardTableColumns.tsx
@@ -28,7 +28,7 @@ export function getCardTableColumns({
     {
       id: 'image',
       header: '',
-      size: 50,
+      size: 80,
       enableSorting: false,
       cell: ({ row }) => <ImageCell card={row.original} skills={{}} locale={locale} />,
     },

--- a/src/components/cards/cardTableColumns.tsx
+++ b/src/components/cards/cardTableColumns.tsx
@@ -28,7 +28,7 @@ export function getCardTableColumns({
     {
       id: 'image',
       header: '',
-      size: 50,
+      size: 65,
       enableSorting: false,
       cell: ({ row }) => <ImageCell card={row.original} skills={{}} locale={locale} />,
     },

--- a/src/components/cards/cardTableColumns.tsx
+++ b/src/components/cards/cardTableColumns.tsx
@@ -3,6 +3,7 @@ import type { Card, AcquisitionSource } from '../../types/card';
 import type { SupportedLocale } from '../../lib/i18n';
 import { formatNumber, formatDescription } from '../../lib/formatters';
 import { computeMlbStats, substituteSkillTemplate } from '../../lib/lb';
+import { highlightHtml, highlightText } from '../../lib/highlightSkillText';
 import { AttributeIcon, TypeIcon, RarityStars } from './GameIcon';
 import { ImageCell } from './cells';
 
@@ -283,7 +284,7 @@ export function getCardTableColumns({
           ? { value: skill.slv_mlb, probability: skill.prob_mlb, delay1: skill.delay_mlb }
           : { value: skill.slv_lb0, probability: skill.prob_lb0, delay1: skill.delay_lb0 };
         const substituted = substituteSkillTemplate(skill.description, vals);
-        const formattedDesc = formatDescription(substituted);
+        const formattedDesc = highlightHtml(formatDescription(substituted));
         return (
           <span
             className="text-sm block max-w-[300px] leading-snug"
@@ -303,7 +304,7 @@ export function getCardTableColumns({
         if (!ability) return <span className="text-secondary text-sm">-</span>;
         return (
           <span className="text-sm block max-w-[200px] leading-snug" title={ability.name}>
-            {ability.description}
+            {highlightText(ability.description)}
           </span>
         );
       },
@@ -318,7 +319,7 @@ export function getCardTableColumns({
         if (!ability) return <span className="text-secondary text-sm">-</span>;
         return (
           <span className="text-sm block max-w-[200px] leading-snug" title={ability.name}>
-            {ability.description}
+            {highlightText(ability.description)}
           </span>
         );
       },

--- a/src/components/cards/cardTableColumns.tsx
+++ b/src/components/cards/cardTableColumns.tsx
@@ -28,7 +28,7 @@ export function getCardTableColumns({
     {
       id: 'image',
       header: '',
-      size: 80,
+      size: 50,
       enableSorting: false,
       cell: ({ row }) => <ImageCell card={row.original} skills={{}} locale={locale} />,
     },

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -421,11 +421,11 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
         <!-- Mobile Navigation -->
         <div id="mobile-menu" class="hidden md:hidden pb-4">
           <div class="flex flex-col gap-2">
-            <a href={navLinks.home} class="link py-2 touch-target">Cards</a>
-            <a href={navLinks.calendar} class="link py-2 touch-target">Calendar</a>
-            <a href={navLinks.updates} class="link py-2 touch-target">Updates</a>
-            <a href={navLinks.blog} class="link py-2 touch-target">Blog</a>
-            <a href={navLinks.tools} class="link py-2 touch-target">Tools</a>
+            <a href={navLinks.home} class="link px-4 py-2 touch-target">Cards</a>
+            <a href={navLinks.calendar} class="link px-4 py-2 touch-target">Calendar</a>
+            <a href={navLinks.updates} class="link px-4 py-2 touch-target">Updates</a>
+            <a href={navLinks.blog} class="link px-4 py-2 touch-target">Blog</a>
+            <a href={navLinks.tools} class="link px-4 py-2 touch-target">Tools</a>
           </div>
         </div>
       </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -119,16 +119,16 @@ const navLinks = {
 // Set MAINTENANCE_ENABLED = false to hide without deleting the config/messages.
 // Bump MAINTENANCE_VERSION (e.g. change the date/slug) to force the banner to
 // re-appear for users who previously dismissed it.
-const MAINTENANCE_ENABLED = false;
-const MAINTENANCE_VERSION = "2026-04-14-maintenance";
+const MAINTENANCE_ENABLED = true;
+const MAINTENANCE_VERSION = "2026-05-06-new-theme";
 // Server-side messages using fixed GMT+8 times; client script refines to local tz
 const maintenanceMessages: Record<string, string> = {
-  en:      'Game servers are down for maintenance (Apr 14, 15:00 \u2013 Apr 15, 15:00 GMT+8)',
-  ja:      '\u30b2\u30fc\u30e0\u30b5\u30fc\u30d0\u30fc\u306f\u30e1\u30f3\u30c6\u30ca\u30f3\u30b9\u4e2d\u3067\u3059\uff08Apr 14, 15:00 \u301c Apr 15, 15:00 GMT+8\uff09',
-  ko:      '\uac8c\uc784 \uc11c\ubc84\uac00 \uc810\uac80 \uc911\uc785\ub2c8\ub2e4 (Apr 14, 15:00 ~ Apr 15, 15:00 GMT+8)',
-  'zh-cn': '\u6e38\u620f\u670d\u52a1\u5668\u6b63\u5728\u7ef4\u62a4\u4e2d\uff08Apr 14, 15:00 \u81f3 Apr 15, 15:00 GMT+8\uff09',
-  'zh-tw': '\u9042\u6232\u4f3a\u670d\u5668\u6b63\u5728\u7dad\u8b77\u4e2d\uff08Apr 14, 15:00 \u81f3 Apr 15, 15:00 GMT+8\uff09',
-  es:      'Los servidores del juego est\u00e1n en mantenimiento (Apr 14, 15:00 \u2013 Apr 15, 15:00 GMT+8)',
+  en:      'New "Spirit" theme is now available! Click the "✦ Classic" button in the header to try it — same button switches back.',
+  ja:      '\u65b0\u30c6\u30fc\u30de\u300cSpirit\u300d\u304c\u5229\u7528\u53ef\u80fd\u306b\u306a\u308a\u307e\u3057\u305f\uff01\u30d8\u30c3\u30c0\u30fc\u306e\u300c\u2724 Classic\u300d\u30dc\u30bf\u30f3\u3092\u30af\u30ea\u30c3\u30af\u3057\u3066\u304a\u8a66\u3057\u304f\u3060\u3055\u3044\u3002\u540c\u3058\u30dc\u30bf\u30f3\u3067\u5207\u308a\u66ff\u3048\u3089\u308c\u307e\u3059\u3002',
+  ko:      '\uc0c8\ub85c\uc6b4 "Spirit" \ud14c\ub9c8\ub97c \uc0ac\uc6a9\ud560 \uc218 \uc788\uc2b5\ub2c8\ub2e4! "\u2724 Classic" \ubc84\ud2bc\uc744 \ub20c\ub7ec\uc11c \ud655\uc778\ud558\uc138\uc694. \ub3d9\uc77c\ud55c \ubc84\ud2bc\uc73c\ub85c \ub420\uc544\uac08 \uc218 \uc788\uc2b5\ub2c8\ub2e4.',
+  'zh-cn': '\u5168\u65b0\u201cSpirit\u201d\u4e3b\u9898\u5df2\u4e0a\u7ebf\uff01\u70b9\u51fb\u9875\u5934\u201c\u2724 Classic\u201d\u6309\u94ae\u5c1d\u8bd5\u65b0\u4e3b\u9898\u2014\u2014\u540c\u6837\u6309\u94ae\u53ef\u5207\u56de\u3002',
+  'zh-tw': '\u5168\u65b0\u300cSpirit\u300d\u4e3b\u984c\u5df2\u4e0a\u7dda\uff01\u9ede\u64ca\u9801\u9762\u300c\u2724 Classic\u300d\u6309\u9215\u8a66\u7528\u65b0\u4e3b\u984c\u2014\u2014\u540c\u6a23\u6309\u9215\u53ef\u5207\u56de\u3002',
+  es:      '\u00a1Nuevo tema "Spirit" disponible! Haz clic en el bot\u00f3n "\u2724 Classic" de la cabecera para probarlo. El mismo bot\u00f3n cambia de vuelta.',
 };
 const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages['en'];
 ---

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -297,8 +297,8 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
           }
         } catch(e) {}
 
-        // Auto-hide after maintenance end: Apr 15, 2026 15:00 GMT+8 = 1776236400000 UTC
-        var MAINTENANCE_END = 1776236400000;
+        // Auto-hide after ~2 weeks: May 20, 2026 00:00 GMT+8 = 1747699200000 UTC
+        var MAINTENANCE_END = 1747699200000;
         if (Date.now() >= MAINTENANCE_END) {
           var b = document.getElementById('maintenance-banner');
           if (b) b.style.display = 'none';
@@ -313,35 +313,6 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
           }, remaining);
         }
 
-        // Format start/end in the user's local timezone
-        var MAINTENANCE_START = 1776150000000; // Apr 14, 2026 15:00 GMT+8 = 07:00 UTC
-        var fmtOpts = { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', timeZoneName: 'short' };
-        function fmtTime(epoch, locale) {
-          try {
-            return new Date(epoch).toLocaleString(locale || undefined, fmtOpts);
-          } catch(e) {
-            return new Date(epoch).toLocaleString(undefined, fmtOpts);
-          }
-        }
-        var templates = {
-          en:     function(s, e) { return "Game servers are down for maintenance (" + s + " \u2013 " + e + ")"; },
-          ja:     function(s, e) { return "\u30b2\u30fc\u30e0\u30b5\u30fc\u30d0\u30fc\u306f\u30e1\u30f3\u30c6\u30ca\u30f3\u30b9\u4e2d\u3067\u3059\uff08" + s + " \u301c " + e + "\uff09"; },
-          ko:     function(s, e) { return "\uac8c\uc784 \uc11c\ubc84\uac00 \uc810\uac80 \uc911\uc785\ub2c8\ub2e4 (" + s + " ~ " + e + ")"; },
-          'zh-cn':function(s, e) { return "\u6e38\u620f\u670d\u52a1\u5668\u6b63\u5728\u7ef4\u62a4\u4e2d\uff08" + s + " \u81f3 " + e + "\uff09"; },
-          'zh-tw':function(s, e) { return "\u9042\u6232\u4f3a\u670d\u5668\u6b63\u5728\u7dad\u8b77\u4e2d\uff08" + s + " \u81f3 " + e + "\uff09"; },
-          es:     function(s, e) { return "Los servidores del juego est\u00e1n en mantenimiento (" + s + " \u2013 " + e + ")"; }
-        };
-        function setMsg(lang) {
-          var el = document.getElementById('maintenance-msg');
-          if (!el) return;
-          var tmpl = templates[lang] || templates['en'];
-          var bcp = lang === 'zh-cn' ? 'zh-Hans' : lang === 'zh-tw' ? 'zh-Hant' : lang;
-          el.textContent = tmpl(fmtTime(MAINTENANCE_START, bcp), fmtTime(MAINTENANCE_END, bcp));
-        }
-
-        // Refine initial message with local timezone formatting (server already rendered correct locale)
-        setMsg(currentLocale);
-
         // Close button — saves current version so banner stays hidden until version changes
         var closeBtn = document.getElementById('maintenance-close');
         if (closeBtn) {
@@ -351,11 +322,6 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
             if (banner) banner.style.display = 'none';
           });
         }
-
-        // Update message on locale change
-        window.addEventListener('otogidb-locale-change', function(e) {
-          setMsg(e.detail.locale);
-        });
       })();
     </script>
     <header class="sticky top-0 z-40 border-b" style="background-color: var(--color-header); border-color: var(--color-border);">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -157,6 +157,17 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
     <!-- Prevent flash of wrong theme -->
     <script is:inline set:html={themeInitScript} />
 
+    <!-- Prevent flash of wrong style variant -->
+    <script is:inline>
+      (function() {
+        try {
+          if (localStorage.getItem('otogidb-style-variant') === 'new') {
+            document.documentElement.setAttribute('data-theme', 'new');
+          }
+        } catch(e) {}
+      })();
+    </script>
+
     <!-- Locale detection (soft default from browser) -->
     <script is:inline set:html={localeInitScript} />
 
@@ -244,7 +255,7 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
     -->
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=optional"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@600&display=optional"
     />
 
     <!-- Preload icon files on card table pages to start downloads before JS hydrates -->
@@ -351,7 +362,7 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
       <div class="container mx-auto px-4">
         <nav class="flex items-center justify-between h-14 md:h-16">
           <!-- Logo -->
-          <a href={navLinks.home} class="flex items-center gap-2 font-bold text-lg" style="color: var(--color-text);">
+          <a href={navLinks.home} class="site-logo flex items-center gap-2 font-bold text-lg" style="color: var(--color-text);">
             <span>OtogiDB</span>
           </a>
 
@@ -382,6 +393,16 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
               <svg class="w-5 h-5 block dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
               </svg>
+            </button>
+
+            <!-- Style variant toggle -->
+            <button
+              id="style-variant-toggle"
+              class="btn-secondary px-2 py-1 rounded-md text-xs font-medium flex items-center gap-1"
+              aria-label="Toggle style variant"
+              title="Toggle style variant"
+            >
+              <span id="style-variant-label">✦ Classic</span>
             </button>
 
             <!-- Mobile menu button -->
@@ -459,6 +480,28 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
     <DebugPanel client:load />
 
     <script>
+      // Style variant toggle
+      const styleToggle = document.getElementById('style-variant-toggle');
+      const styleLabel = document.getElementById('style-variant-label');
+      function updateStyleLabel() {
+        const isNew = document.documentElement.getAttribute('data-theme') === 'new';
+        if (styleLabel) styleLabel.textContent = isNew ? '✦ Spirit' : '✦ Classic';
+      }
+      updateStyleLabel();
+      if (styleToggle) {
+        styleToggle.addEventListener('click', () => {
+          const isNew = document.documentElement.getAttribute('data-theme') === 'new';
+          if (isNew) {
+            document.documentElement.removeAttribute('data-theme');
+            localStorage.setItem('otogidb-style-variant', 'classic');
+          } else {
+            document.documentElement.setAttribute('data-theme', 'new');
+            localStorage.setItem('otogidb-style-variant', 'new');
+          }
+          updateStyleLabel();
+        });
+      }
+
       // Theme toggle - explicitly saves user choice to override system preference
       const themeToggle = document.getElementById('theme-toggle');
       if (themeToggle) {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -255,7 +255,7 @@ const maintenanceMsg = maintenanceMessages[currentLocale] ?? maintenanceMessages
     -->
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@600&display=optional"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&family=Noto+Serif+JP:wght@600&family=Reggae+One&display=optional"
     />
 
     <!-- Preload icon files on card table pages to start downloads before JS hydrates -->

--- a/src/lib/highlightSkillText.tsx
+++ b/src/lib/highlightSkillText.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from 'react';
+
+interface Rule { re: RegExp; cls: string }
+
+const RULES: Rule[] = [
+  // Numeric values with game units — numbers followed by DMG, HP, or %
+  { re: /\b\d[\d,]*(?:\.\d+)?\s*(?:DMG|HP|%)/g, cls: 'hl-value' },
+  // Turn/hit durations
+  { re: /\b\d+\s+(?:turns?|hits?)\b/gi, cls: 'hl-value' },
+  // Damage type keywords — order matters: compound phrases before standalone DMG
+  { re: /\bCrit(?:ical)?\s+DMG\b/gi, cls: 'hl-crit-dmg' },
+  { re: /\bSkill\s+DMG\b/gi, cls: 'hl-skill-dmg' },
+  { re: /\bCrit(?:ical)?\s+Rate\b/gi, cls: 'hl-crit-rate' },
+  { re: /\bATK\s+(?:Speed|SPD)\b/gi, cls: 'hl-atk-speed' },
+  { re: /\bDMG\s+taken\b/gi, cls: 'hl-dmg-taken' },
+  { re: /\bmore\s+DMG\b/gi, cls: 'hl-dmg-taken' },
+  { re: /\bDMG\b/g, cls: 'hl-dmg' },
+  // Timing triggers — wave start conditions
+  { re: /\bwave start\b/gi, cls: 'hl-trigger' },
+  { re: /\bstart of (?:each|every|the (?:first|last|final|next)) wave\b/gi, cls: 'hl-trigger' },
+  // Resource/stat effects — EXP and drop rate
+  { re: /\bEXP\b/g, cls: 'hl-value' },
+  { re: /\bdrop rate\b/gi, cls: 'hl-value' },
+  // Attribute names — colored in their team colors via CSS custom properties
+  { re: /\bDivina\b/g, cls: 'hl-divina' },
+  { re: /\bAnima\b/g, cls: 'hl-anima' },
+  { re: /\bPhantasma\b/g, cls: 'hl-phantasma' },
+];
+
+interface Span { start: number; end: number; cls: string }
+
+function collectSpans(text: string): Span[] {
+  const spans: Span[] = [];
+  for (const { re, cls } of RULES) {
+    const r = new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g');
+    r.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = r.exec(text)) !== null) {
+      spans.push({ start: m.index, end: m.index + m[0].length, cls });
+    }
+  }
+  // Sort by start; on tie keep longer match first; deduplicate overlaps
+  spans.sort((a, b) => a.start - b.start || b.end - a.end);
+  const deduped: Span[] = [];
+  for (const s of spans) {
+    const prev = deduped[deduped.length - 1];
+    if (!prev || s.start >= prev.end) deduped.push(s);
+  }
+  return deduped;
+}
+
+/** Wraps keywords in the text portion of an HTML string, leaving tags untouched. */
+export function highlightHtml(html: string): string {
+  return html.replace(/(<[^>]*>)|([^<]+)/g, (_, tag, text) => {
+    if (tag !== undefined) return tag;
+    const spans = collectSpans(text);
+    if (!spans.length) return text;
+    let result = '';
+    let pos = 0;
+    for (const { start, end, cls } of spans) {
+      if (start > pos) result += text.slice(pos, start);
+      result += `<span class="${cls}">${text.slice(start, end)}</span>`;
+      pos = end;
+    }
+    if (pos < text.length) result += text.slice(pos);
+    return result;
+  });
+}
+
+/** Wraps keywords in plain text, returning a React node array. */
+export function highlightText(text: string | undefined): ReactNode {
+  if (!text) return null;
+  const spans = collectSpans(text);
+  if (!spans.length) return text;
+  const nodes: ReactNode[] = [];
+  let pos = 0;
+  for (const { start, end, cls } of spans) {
+    if (start > pos) nodes.push(text.slice(pos, start));
+    nodes.push(<span key={start} className={cls}>{text.slice(start, end)}</span>);
+    pos = end;
+  }
+  if (pos < text.length) nodes.push(text.slice(pos));
+  return <>{nodes}</>;
+}

--- a/src/pages/en/cards/[id].astro
+++ b/src/pages/en/cards/[id].astro
@@ -331,7 +331,7 @@ const jsonLd = {
   <!-- JSON-LD Structured Data -->
   <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
-  <div class="container mx-auto px-3 sm:px-4 py-4 sm:py-6">
+  <div class="container mx-auto px-3 sm:px-4 py-4 sm:py-6" data-attribute={card.stats.attribute_name}>
     <!-- Breadcrumb -->
     <nav class="mb-3 sm:mb-4 text-xs sm:text-sm">
       <a href="/en/" class="link">Cards</a>
@@ -874,7 +874,7 @@ const jsonLd = {
 
         <!-- Availability -->
         {card.acquisition && card.acquisition.sources.length > 0 && (
-          <div class="card p-3 sm:p-4">
+          <div class="card p-3 sm:p-4" data-section="availability">
             <div class="flex items-center justify-between mb-3 sm:mb-4">
               <h2 class="font-semibold text-sm sm:text-base">Availability</h2>
               <AvailabilityBadge

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -42,10 +42,7 @@ const jsonLd = {
   <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
   <div class="container mx-auto px-4 py-6">
-    <div class="mb-4 md:mb-6">
-      <h1 class="text-lg sm:text-xl md:text-3xl font-bold mb-1 md:mb-2">Otogi: Spirit Agents Database</h1>
-      <p class="text-secondary text-sm md:text-base hidden sm:block">Browse all {cardCount} characters with complete stats, skills, and abilities. Filter by attribute, type, or rarity.</p>
-    </div>
+    <h1 class="sr-only">Otogi: Spirit Agents Database</h1>
 
     <!-- Card Table (React Island) -->
     <div class="card p-4">

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -41,7 +41,7 @@ const jsonLd = {
   <!-- JSON-LD Structured Data -->
   <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
-  <div class="container mx-auto px-4 py-6">
+  <div class="container mx-auto px-4 py-6 my-4">
     <h1 class="sr-only">Otogi: Spirit Agents Database</h1>
 
     <!-- Card Table (React Island) -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -845,8 +845,31 @@ html[data-theme="new"]:not(.dark) .data-table tbody tr:hover td[data-column="nam
   color: var(--color-text);
 }
 
+/* ─── Spirit Theme: Larger Card Images in Table ─────────────────────────── */
+/* Increase image height for better visual identification - maintain aspect ratio */
+[data-theme="new"] .data-table td[data-column="image"] img {
+  height: 52px;
+  width: auto;
+  min-width: 39px;
+}
+
+/* Adjust row padding to accommodate larger images */
+[data-theme="new"] .data-table tbody td[data-column="image"] {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+/* Mobile: slightly smaller for space constraints */
+@media (max-width: 640px) {
+  [data-theme="new"] .data-table td[data-column="image"] img {
+    height: 46px;
+    width: auto;
+    min-width: 34px;
+  }
+}
 
 
+/* ─── Card Detail Page — Spirit Theme ─────────────────────────────────────── */
 /* ─── Card Detail Page — Spirit Theme ─────────────────────────────────────── */
 
 /* 1. Ability & skill descriptions: full text color, not dimmed secondary */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -114,6 +114,45 @@
     --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.5);
   }
 
+  /* Spirit Scroll theme — ink & mist variant (dark mode only) */
+  .dark[data-theme="new"] {
+    --color-bg: #0D0C12;
+    --color-surface: #17151F;
+    --color-header: #0A0910;
+    --color-text: #EDE8D8;
+    --color-text-secondary: #9E9A8E;
+    --color-accent: #9E8FA8;
+    --color-accent-hover: #B3A5BE;
+    --color-border: #231F2E;
+    --color-highlight: #C4A882;
+    --color-divina: #C4A832;
+    --color-anima: #C45A5A;
+    --color-phantasma: #7A5A8E;
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 10px 20px rgba(0, 0, 0, 0.6);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root[data-theme="new"]:not(.light-override) {
+      --color-bg: #0D0C12;
+      --color-surface: #17151F;
+      --color-header: #0A0910;
+      --color-text: #EDE8D8;
+      --color-text-secondary: #9E9A8E;
+      --color-accent: #9E8FA8;
+      --color-accent-hover: #B3A5BE;
+      --color-border: #231F2E;
+      --color-highlight: #C4A882;
+      --color-divina: #C4A832;
+      --color-anima: #C45A5A;
+      --color-phantasma: #7A5A8E;
+      --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+      --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.5);
+      --shadow-lg: 0 10px 20px rgba(0, 0, 0, 0.6);
+    }
+  }
+
   html {
     scroll-behavior: smooth;
     /* Always show scrollbar to prevent layout shift when content changes */
@@ -357,4 +396,43 @@
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
   }
+}
+
+/* ── Spirit Scroll micro-details ──────────────────────────────────────────── */
+
+/* Scroll marker: left accent border on hovered table rows */
+.dark[data-theme="new"] .data-table tbody tr:hover td:first-child {
+  border-left: 2px solid var(--color-accent);
+}
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="new"]:not(.light-override) .data-table tbody tr:hover td:first-child {
+    border-left: 2px solid var(--color-accent);
+  }
+}
+
+/* Badge dimensional treatment: subtle inner glow */
+.dark[data-theme="new"] .badge {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="new"]:not(.light-override) .badge {
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 1px 2px rgba(0, 0, 0, 0.3);
+  }
+}
+
+/* Filter chips as ink seals: nearly square corners */
+.dark[data-theme="new"] .filter-chip {
+  border-radius: 3px;
+}
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="new"]:not(.light-override) .filter-chip {
+    border-radius: 3px;
+  }
+}
+
+/* Site logo: calligraphic serif font in Spirit Scroll mode */
+[data-theme="new"] .site-logo {
+  font-family: 'Noto Serif JP', 'Noto Sans JP', serif;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -125,9 +125,9 @@
     --color-accent-hover: #B3A5BE;
     --color-border: #231F2E;
     --color-highlight: #C4A882;
-    --color-divina: #C4A832;
-    --color-anima: #C45A5A;
-    --color-phantasma: #7A5A8E;
+    --color-divina: #5082FF;
+    --color-anima: #3CC85A;
+    --color-phantasma: #FF5028;
     --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
     --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.5);
     --shadow-lg: 0 10px 20px rgba(0, 0, 0, 0.6);
@@ -144,9 +144,9 @@
       --color-accent-hover: #B3A5BE;
       --color-border: #231F2E;
       --color-highlight: #C4A882;
-      --color-divina: #C4A832;
-      --color-anima: #C45A5A;
-      --color-phantasma: #7A5A8E;
+      --color-divina: #5082FF;
+      --color-anima: #3CC85A;
+      --color-phantasma: #FF5028;
       --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
       --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.5);
       --shadow-lg: 0 10px 20px rgba(0, 0, 0, 0.6);
@@ -164,9 +164,9 @@
     --color-accent-hover: #2D4A48;
     --color-border: #D4CEC4;
     --color-highlight: #B8913A;
-    --color-divina: #9E7A20;
-    --color-anima: #A03535;
-    --color-phantasma: #6A3D8A;
+    --color-divina: #2A4DBB;
+    --color-anima: #2A7A48;
+    --color-phantasma: #9E2828;
   }
 
   html {
@@ -419,41 +419,420 @@
   }
 }
 
+/* ── Spirit Scroll background texture ─────────────────────────────────────── */
+
+/* Ghostly mist overlay — body carries the image, main must be transparent.
+   Opacity is controlled by the dark gradient on top: alpha = 1 - desired_image_opacity */
+.dark[data-theme="new"] body {
+  background-image:
+    linear-gradient(rgba(13,12,18,0.96), rgba(13,12,18,0.96)),
+    url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_800/v1777959000/ghostly_-_Copy_m9e4s7.png');
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+@media (min-width: 1024px) {
+  .dark[data-theme="new"] body {
+    background-image:
+      linear-gradient(rgba(13,12,18,0.96), rgba(13,12,18,0.96)),
+      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1280/v1777959000/ghostly_-_Copy_m9e4s7.png');
+  }
+}
+
+@media (min-width: 1680px) {
+  .dark[data-theme="new"] body {
+    background-image:
+      linear-gradient(rgba(13,12,18,0.96), rgba(13,12,18,0.96)),
+      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1920/v1777959000/ghostly_-_Copy_m9e4s7.png');
+  }
+}
+
+/* main has an inline background-color that blocks the body image — clear it */
+.dark[data-theme="new"] main,
+html[data-theme="new"]:not(.dark) main {
+  background-color: transparent !important;
+}
+
+/* Ghostly mist overlay — light spirit mode, parchment tint over the same image */
+html[data-theme="new"]:not(.dark) body {
+  background-image:
+    linear-gradient(rgba(240,237,228,0.93), rgba(240,237,228,0.93)),
+    url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_800/v1777959000/ghostly_-_Copy_m9e4s7.png');
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+@media (min-width: 1024px) {
+  html[data-theme="new"]:not(.dark) body {
+    background-image:
+      linear-gradient(rgba(240,237,228,0.93), rgba(240,237,228,0.93)),
+      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1280/v1777959000/ghostly_-_Copy_m9e4s7.png');
+  }
+}
+
+@media (min-width: 1680px) {
+  html[data-theme="new"]:not(.dark) body {
+    background-image:
+      linear-gradient(rgba(240,237,228,0.93), rgba(240,237,228,0.93)),
+      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1920/v1777959000/ghostly_-_Copy_m9e4s7.png');
+  }
+}
+
 /* ── Spirit Scroll micro-details ──────────────────────────────────────────── */
 
 /* Scroll marker: left accent border on hovered table rows */
-.dark[data-theme="new"] .data-table tbody tr:hover td:first-child {
-  border-left: 2px solid var(--color-accent);
-}
-@media (prefers-color-scheme: dark) {
-  :root[data-theme="new"]:not(.light-override) .data-table tbody tr:hover td:first-child {
-    border-left: 2px solid var(--color-accent);
-  }
+[data-theme="new"] .data-table tbody tr:hover td:first-child {
+  box-shadow: inset 2px 0 0 var(--color-accent);
 }
 
-/* Badge dimensional treatment: subtle inner glow */
-.dark[data-theme="new"] .badge {
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 1px 2px rgba(0, 0, 0, 0.3);
+/* Badge wax label: pill shape, tinted fill, embossed depth — no outline border */
+[data-theme="new"] .badge {
+  border-radius: 50px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  box-shadow:
+    1px 2px 5px rgba(0, 0, 0, 0.4),
+    inset 2px 2px 5px rgba(0, 0, 0, 0.35),
+    inset -1px -1px 3px rgba(255, 255, 255, 0.12);
 }
-@media (prefers-color-scheme: dark) {
-  :root[data-theme="new"]:not(.light-override) .badge {
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 1px 2px rgba(0, 0, 0, 0.3);
-  }
+
+/* Image icons — simple drop shadow for subtle definition */
+[data-theme="new"] .game-icon img {
+  filter: drop-shadow(1px 2px 3px rgba(0, 0, 0, 0.5));
 }
 
 /* Filter chips as ink seals: nearly square corners */
-.dark[data-theme="new"] .filter-chip {
+[data-theme="new"] .filter-chip {
   border-radius: 3px;
 }
-@media (prefers-color-scheme: dark) {
-  :root[data-theme="new"]:not(.light-override) .filter-chip {
-    border-radius: 3px;
+
+/* Site logo: brush-stroke display font in Spirit Scroll mode */
+[data-theme="new"] .site-logo {
+  font-family: 'Reggae One', 'Noto Serif JP', serif;
+  font-weight: 400;
+  letter-spacing: 0.03em;
+}
+
+/* Nav links: same brush-stroke font in Spirit Scroll mode */
+[data-theme="new"] header .link {
+  font-family: 'Reggae One', 'Noto Serif JP', serif;
+  font-weight: 400;
+  letter-spacing: 0.03em;
+}
+
+/* Nav links: spirit glow on hover (dark spirit mode) */
+.dark[data-theme="new"] header .link {
+  text-shadow: none;
+  transition: text-shadow 0.4s ease;
+}
+
+.dark[data-theme="new"] header .link:hover {
+  text-shadow:
+    0 0 2px rgba(165, 195, 255, 0.95),
+    0 0 12px rgba(75, 115, 245, 0.65),
+    0 0 28px rgba(55, 90, 230, 0.35);
+  animation: spirit-header-breathe-dark 5s ease-in-out infinite;
+  text-decoration: none;
+}
+
+/* Spirit header glow — dark mode: blue-indigo aura that breathes with the page */
+.dark[data-theme="new"] .site-logo {
+  animation: spirit-header-breathe-dark 5s ease-in-out infinite;
+}
+
+@keyframes spirit-header-breathe-dark {
+  0%, 100% {
+    text-shadow:
+      0 0 2px rgba(165, 195, 255, 0.95),
+      0 0 12px rgba(75, 115, 245, 0.65),
+      0 0 28px rgba(55, 90, 230, 0.35);
+  }
+  50% {
+    text-shadow:
+      0 0 2px rgba(165, 195, 255, 0.95),
+      0 0 22px rgba(75, 115, 245, 0.75),
+      0 0 45px rgba(55, 90, 230, 0.45),
+      0 0 65px rgba(35, 55, 185, 0.2);
   }
 }
 
-/* Site logo: calligraphic serif font in Spirit Scroll mode */
-[data-theme="new"] .site-logo {
-  font-family: 'Noto Serif JP', 'Noto Sans JP', serif;
+/* Spirit header glow — light mode: deep blue aura on parchment */
+html[data-theme="new"]:not(.dark) .site-logo {
+  animation: spirit-header-breathe-light 5s ease-in-out infinite;
+}
+
+html[data-theme="new"]:not(.dark) header .link {
+  text-shadow: none;
+  transition: text-shadow 0.4s ease;
+}
+
+html[data-theme="new"]:not(.dark) header .link:hover {
+  text-shadow:
+    0 0 2px rgba(30, 60, 200, 0.7),
+    0 0 10px rgba(40, 80, 210, 0.35),
+    0 0 22px rgba(30, 60, 190, 0.18);
+  animation: spirit-header-breathe-light 5s ease-in-out infinite;
+  text-decoration: none;
+}
+
+@keyframes spirit-header-breathe-light {
+  0%, 100% {
+    text-shadow:
+      0 0 2px rgba(30, 60, 200, 0.7),
+      0 0 10px rgba(40, 80, 210, 0.35),
+      0 0 22px rgba(30, 60, 190, 0.18);
+  }
+  50% {
+    text-shadow:
+      0 0 2px rgba(30, 60, 200, 0.8),
+      0 0 16px rgba(40, 80, 210, 0.5),
+      0 0 34px rgba(30, 60, 190, 0.28),
+      0 0 50px rgba(20, 45, 170, 0.12);
+  }
+}
+
+/* Spirit glow breathing — anchor holds readability, ambient expands/contracts */
+@keyframes respiration {
+  0%, 100% {
+    text-shadow:
+      0 0 1px var(--anchor),
+      0 0 6px var(--halo);
+  }
+  50% {
+    text-shadow:
+      0 0 1px var(--anchor),
+      0 0 20px var(--halo),
+      0 0 36px var(--fog);
+  }
+}
+
+/* Baseline letter spacing — always on in Spirit Scroll, never shifts on hover */
+[data-theme="new"] .data-table tbody td {
+  letter-spacing: 0.06em;
+}
+
+/* Divina — blue spirit */
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="divina"]:hover td:not([data-column="bonds"]):not([data-column="sources"]):not([data-column="skill"]):not([data-column="ability1"]):not([data-column="ability2"]) {
+  --anchor: rgba(180, 210, 255, 0.95);
+  --halo: rgba(80, 130, 255, 0.55);
+  --fog: rgba(30, 70, 220, 0.18);
+  animation: respiration 5s ease-in-out infinite;
+}
+
+/* Anima — green spirit */
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="anima"]:hover td:not([data-column="bonds"]):not([data-column="sources"]):not([data-column="skill"]):not([data-column="ability1"]):not([data-column="ability2"]) {
+  --anchor: rgba(140, 255, 160, 0.95);
+  --halo: rgba(60, 200, 90, 0.55);
+  --fog: rgba(15, 150, 50, 0.18);
+  animation: respiration 5s ease-in-out infinite;
+}
+
+/* Phantasma — red spirit */
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="phantasma"]:hover td:not([data-column="bonds"]):not([data-column="sources"]):not([data-column="skill"]):not([data-column="ability1"]):not([data-column="ability2"]) {
+  --anchor: rgba(255, 110, 90, 0.99);
+  --halo: rgba(255, 55, 40, 0.7);
+  --fog: rgba(200, 20, 10, 0.22);
+  animation: respiration 5s ease-in-out infinite;
+}
+
+/* Neutral — lavender */
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="neutral"]:hover td:not([data-column="bonds"]):not([data-column="sources"]),
+.dark[data-theme="new"] .data-table tbody tr:not([data-attribute]):hover td:not([data-column="bonds"]):not([data-column="sources"]):not([data-column="skill"]):not([data-column="ability1"]):not([data-column="ability2"]) {
+  --anchor: rgba(200, 185, 210, 0.9);
+  --halo: rgba(158, 143, 168, 0.5);
+  --fog: rgba(110, 95, 130, 0.18);
+  animation: respiration 5s ease-in-out infinite;
+}
+
+/* Light mode spirit glows — darker anchors since background is parchment */
+html[data-theme="new"]:not(.dark) .data-table tbody tr[data-attribute="divina"]:hover td:not([data-column="bonds"]):not([data-column="sources"]):not([data-column="skill"]):not([data-column="ability1"]):not([data-column="ability2"]) {
+  --anchor: rgba(30, 60, 180, 0.9);
+  --halo: rgba(40, 80, 220, 0.45);
+  --fog: rgba(20, 50, 200, 0.14);
+  animation: respiration 5s ease-in-out infinite;
+}
+
+html[data-theme="new"]:not(.dark) .data-table tbody tr[data-attribute="anima"]:hover td:not([data-column="bonds"]):not([data-column="sources"]):not([data-column="skill"]):not([data-column="ability1"]):not([data-column="ability2"]) {
+  --anchor: rgba(15, 120, 50, 0.9);
+  --halo: rgba(25, 150, 65, 0.45);
+  --fog: rgba(10, 110, 35, 0.14);
+  animation: respiration 5s ease-in-out infinite;
+}
+
+html[data-theme="new"]:not(.dark) .data-table tbody tr[data-attribute="phantasma"]:hover td:not([data-column="bonds"]):not([data-column="sources"]):not([data-column="skill"]):not([data-column="ability1"]):not([data-column="ability2"]) {
+  --anchor: rgba(160, 30, 30, 0.9);
+  --halo: rgba(190, 40, 40, 0.45);
+  --fog: rgba(140, 15, 15, 0.14);
+  animation: respiration 5s ease-in-out infinite;
+}
+
+html[data-theme="new"]:not(.dark) .data-table tbody tr[data-attribute="neutral"]:hover td:not([data-column="bonds"]):not([data-column="sources"]),
+html[data-theme="new"]:not(.dark) .data-table tbody tr:not([data-attribute]):hover td:not([data-column="bonds"]):not([data-column="sources"]):not([data-column="skill"]):not([data-column="ability1"]):not([data-column="ability2"]) {
+  --anchor: rgba(40, 72, 70, 0.9);
+  --halo: rgba(55, 88, 86, 0.45);
+  --fog: rgba(30, 55, 53, 0.14);
+  animation: respiration 5s ease-in-out infinite;
+}
+
+/* ─── Digital Yūrei — chromatic aberration ghost (inactive) ───────────────
+   To activate: add class="digital-yurei" to any element.
+   Works best on headings or hovered row text at Spirit Scroll dark.
+   ────────────────────────────────────────────────────────────────────────── */
+@keyframes phaseGlitch {
+  0%, 80% {
+    text-shadow:
+      -1px 0px 0px rgba(255, 0, 0, 0.4),
+       1px 0px 0px rgba(0, 255, 255, 0.4);
+  }
+  100% {
+    text-shadow:
+      -2px 0px 2px rgba(255, 0, 0, 0.2),
+       2px 0px 2px rgba(0, 255, 255, 0.2);
+  }
+}
+
+.digital-yurei {
+  text-shadow:
+    -1px 0px 0px rgba(255, 0, 0, 0.4),
+     1px 0px 0px rgba(0, 255, 255, 0.4);
+  animation: phaseGlitch 4s infinite alternate;
+}
+
+/* ─── Spirit Scroll — Typography & Targeted Glow Improvements ─────────────── */
+
+/* Change 2: Reset letter-spacing on dense/excluded columns */
+[data-theme="new"] .data-table tbody td[data-column="skill"],
+[data-theme="new"] .data-table tbody td[data-column="ability1"],
+[data-theme="new"] .data-table tbody td[data-column="ability2"],
+[data-theme="new"] .data-table tbody td[data-column="bonds"],
+[data-theme="new"] .data-table tbody td[data-column="sources"] {
+  letter-spacing: 0;
+}
+
+/* Change 3: Skill/Ability readability — larger text, breathing room */
+[data-theme="new"] .data-table tbody td[data-column="skill"],
+[data-theme="new"] .data-table tbody td[data-column="ability1"],
+[data-theme="new"] .data-table tbody td[data-column="ability2"] {
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+/* Change 4 + 5: Table header hierarchy + lavender ambient */
+[data-theme="new"] .data-table thead th {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   font-weight: 600;
-  letter-spacing: 0.01em;
+}
+
+.dark[data-theme="new"] .data-table thead th {
+  color: var(--color-secondary);
+  text-shadow: 0 0 10px rgba(158, 143, 168, 0.4);
+}
+
+/* Change 6: Static attribute-colored ambient glow on daemon name (always-on) */
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="divina"] td[data-column="name"] a {
+  text-shadow: 0 0 10px rgba(80, 130, 255, 0.25);
+}
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="anima"] td[data-column="name"] a {
+  text-shadow: 0 0 10px rgba(60, 200, 90, 0.25);
+}
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="phantasma"] td[data-column="name"] a {
+  text-shadow: 0 0 10px rgba(255, 80, 60, 0.3);
+}
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="neutral"] td[data-column="name"] a,
+.dark[data-theme="new"] .data-table tbody tr:not([data-attribute]) td[data-column="name"] a {
+  text-shadow: 0 0 10px rgba(158, 143, 168, 0.25);
+}
+
+/* Change 7: Attribute icon colored drop-shadow per attribute */
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="divina"] td[data-column="attribute"] .game-icon img {
+  filter: drop-shadow(0 0 5px rgba(80, 130, 255, 0.55)) drop-shadow(1px 2px 3px rgba(0,0,0,0.5));
+}
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="anima"] td[data-column="attribute"] .game-icon img {
+  filter: drop-shadow(0 0 5px rgba(60, 200, 90, 0.55)) drop-shadow(1px 2px 3px rgba(0,0,0,0.5));
+}
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="phantasma"] td[data-column="attribute"] .game-icon img {
+  filter: drop-shadow(0 0 5px rgba(255, 80, 60, 0.6)) drop-shadow(1px 2px 3px rgba(0,0,0,0.5));
+}
+.dark[data-theme="new"] .data-table tbody tr[data-attribute="neutral"] td[data-column="attribute"] .game-icon img,
+.dark[data-theme="new"] .data-table tbody tr:not([data-attribute]) td[data-column="attribute"] .game-icon img {
+  filter: drop-shadow(0 0 5px rgba(158, 143, 168, 0.5)) drop-shadow(1px 2px 3px rgba(0,0,0,0.5));
+}
+
+/* Change 8: Rarity star gold drop-shadow */
+.dark[data-theme="new"] .data-table tbody td[data-column="rarity"] img {
+  filter: drop-shadow(0 0 4px rgba(255, 200, 80, 0.65)) drop-shadow(1px 1px 2px rgba(0,0,0,0.5));
+}
+
+/* Change 9: Tabular nums on stat columns for perfect alignment */
+[data-theme="new"] .data-table tbody td[data-column="max_atk"],
+[data-theme="new"] .data-table tbody td[data-column="max_hp"],
+[data-theme="new"] .data-table tbody td[data-column="speed"] {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Horizontal Tracking ─────────────────────────────────────────────────── */
+
+/* Visible hairline between rows — #231F2E border is invisible on #0D0C12 bg */
+.dark[data-theme="new"] .data-table tbody td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* Extra vertical padding for row breathing room */
+[data-theme="new"] .data-table td {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+/* Subtle row highlight on hover (overrides the opaque surface colour) */
+.dark[data-theme="new"] .data-table tbody tr:hover td {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+/* ─── Daemon Name Breathing on Row Hover ─────────────────────────────────── */
+/* Apply respiration animation directly to the name link on hover.
+   --anchor / --halo / --fog are inherited from the per-attribute td rule above. */
+.dark[data-theme="new"] .data-table tbody tr:hover td[data-column="name"] a {
+  animation: respiration 5s ease-in-out infinite;
+}
+html[data-theme="new"]:not(.dark) .data-table tbody tr:hover td[data-column="name"] a {
+  animation: respiration 5s ease-in-out infinite;
+}
+
+/* ─── Keyword Highlight Colours — disabled, spans present but unstyled ──────── */
+
+/* ─── Light Spirit Mode Contrast Fixes ────────────────────────────────────── */
+
+/* 1. Rarity stars: deepen gold + anchoring shadow so they read on parchment */
+html[data-theme="new"]:not(.dark) .data-table tbody td[data-column="rarity"] img {
+  filter: saturate(1.2) brightness(0.78) drop-shadow(0 0 1px rgba(0, 0, 0, 0.45));
+}
+
+/* 2. Badge emboss: lighter shadows suit the pale parchment surface */
+html[data-theme="new"]:not(.dark) .badge {
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.18),
+    inset 1px 1px 3px rgba(0, 0, 0, 0.1),
+    inset -1px -1px 2px rgba(255, 255, 255, 0.55);
+}
+
+/* 3. Table headers: deep sepia ink instead of light secondary */
+html[data-theme="new"]:not(.dark) .data-table thead th {
+  color: #3A2E24;
+}
+
+/* 4. Row separators: visible hairline on parchment */
+html[data-theme="new"]:not(.dark) .data-table tbody td {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+/* 5. Subtle row hover tint */
+html[data-theme="new"]:not(.dark) .data-table tbody tr:hover td {
+  background-color: rgba(0, 0, 0, 0.025);
+}
+
+/* 6. Source/acquisition tag pills: add a faint border to separate from parchment */
+html[data-theme="new"]:not(.dark) .data-table td[data-column="sources"] span {
+  border: 1px solid rgba(0, 0, 0, 0.18);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -121,8 +121,8 @@
     --color-header: #0A0910;
     --color-text: #EDE8D8;
     --color-text-secondary: #9E9A8E;
-    --color-accent: #9E8FA8;
-    --color-accent-hover: #B3A5BE;
+    --color-accent: #8B7355;
+    --color-accent-hover: #A0845C;
     --color-border: #231F2E;
     --color-highlight: #C4A882;
     --color-divina: #5082FF;
@@ -153,17 +153,19 @@
     }
   }
 
-  /* Spirit Scroll theme — ink on washi (light mode) */
+  /* Spirit Scroll light mode — ink on washi (light mode) */
   html[data-theme="new"]:not(.dark) {
     --color-bg: #F0EDE4;
     --color-surface: #F9F6F0;
     --color-header: #E8E3D8;
     --color-text: #2b2013;
-    --color-text-secondary: #5C5249;
-    --color-accent: #3D5C5A;
-    --color-accent-hover: #2D4A48;
-    --color-border: #D4CEC4;
-    --color-highlight: #B8913A;
+    --color-text-secondary: #666;
+    --color-border: #D6CFC0;
+    --color-accent: #654321;
+    --color-accent-light: #8B5A2B;
+    --color-highlight: #2b2013;
+    --color-error: #991B1B;
+    --color-success: #065F46;
     --color-divina: #2A4DBB;
     --color-anima: #2A7A48;
     --color-phantasma: #9E2828;
@@ -293,8 +295,14 @@
   }
 
   .data-table td {
-    @apply px-3 py-2;
+    @apply px-3 py-3;
     border-bottom: 1px solid var(--color-border);
+  }
+
+  .data-table {
+    @apply w-full;
+    min-width: 640px;
+    border-collapse: collapse;
   }
 
   .data-table tr:hover td {
@@ -479,6 +487,38 @@ html[data-theme="new"]:not(.dark) body {
 }
 
 /* ── Spirit Scroll micro-details ──────────────────────────────────────────── */
+
+  /* Thin white overlay behind text for readability on parchment */
+  .text-overlay {
+    position: relative;
+    display: inline;
+  }
+  .text-overlay::before {
+    content: '';
+    position: absolute;
+    inset: -2px -4px;
+    background: rgba(255, 255, 255, 0.75);
+    border-radius: 3px;
+    z-index: -1;
+  }
+
+  /* Prevent decorative elements from overlapping text */
+  [data-theme="new"] p,
+  [data-theme="new"] h1,
+  [data-theme="new"] h2,
+  [data-theme="new"] h3,
+  [data-theme="new"] h4,
+  [data-theme="new"] span,
+  [data-theme="new"] a {
+    position: relative;
+    z-index: 1;
+  }
+
+  /* Decorative pseudo-elements stay behind text */
+  [data-theme="new"] ::before,
+  [data-theme="new"] ::after {
+    pointer-events: none;
+  }
 
 /* Scroll marker: left accent border on hovered table rows */
 [data-theme="new"] .data-table tbody tr:hover td:first-child {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -845,6 +845,29 @@ html[data-theme="new"]:not(.dark) .data-table tbody tr:hover td[data-column="nam
   color: var(--color-text);
 }
 
+/* ─── Spirit Theme: Larger Card Images in Table ─────────────────────────── */
+/* Increase image size for better visual identification */
+[data-theme="new"] .data-table td[data-column="image"] img {
+  width: 64px;
+  height: 64px;
+  min-width: 64px;
+}
+
+/* Adjust row height to accommodate larger images */
+[data-theme="new"] .data-table tbody td[data-column="image"] {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+/* Mobile: ensure images don't overflow */
+@media (max-width: 640px) {
+  [data-theme="new"] .data-table td[data-column="image"] img {
+    width: 56px;
+    height: 56px;
+    min-width: 56px;
+  }
+}
+
 
 
 /* ─── Card Detail Page — Spirit Theme ─────────────────────────────────────── */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -153,6 +153,22 @@
     }
   }
 
+  /* Spirit Scroll theme — ink on washi (light mode) */
+  html[data-theme="new"]:not(.dark) {
+    --color-bg: #F0EDE4;
+    --color-surface: #F7F4EE;
+    --color-header: #E8E3D8;
+    --color-text: #1A1614;
+    --color-text-secondary: #5C5249;
+    --color-accent: #3D5C5A;
+    --color-accent-hover: #2D4A48;
+    --color-border: #D4CEC4;
+    --color-highlight: #B8913A;
+    --color-divina: #9E7A20;
+    --color-anima: #A03535;
+    --color-phantasma: #6A3D8A;
+  }
+
   html {
     scroll-behavior: smooth;
     /* Always show scrollbar to prevent layout shift when content changes */
@@ -322,6 +338,11 @@
   /* Light mode only: darken game colors for better contrast on light backgrounds */
   html:not(.dark) .game-color {
     filter: brightness(0.65) saturate(1.3);
+  }
+
+  /* Spirit Scroll light mode uses explicit color values — disable the filter */
+  html[data-theme="new"]:not(.dark) .game-color {
+    filter: none;
   }
 
   /* Link styles */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -426,7 +426,7 @@
 .dark[data-theme="new"] body {
   background-image:
     linear-gradient(rgba(13,12,18,0.96), rgba(13,12,18,0.96)),
-    url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_800/v1777959000/ghostly_-_Copy_m9e4s7.png');
+    url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_800/v1777966115/000040_zydduo.png');
   background-size: cover;
   background-repeat: no-repeat;
 }
@@ -435,7 +435,7 @@
   .dark[data-theme="new"] body {
     background-image:
       linear-gradient(rgba(13,12,18,0.96), rgba(13,12,18,0.96)),
-      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1280/v1777959000/ghostly_-_Copy_m9e4s7.png');
+      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1280/v1777966115/000040_zydduo.png');
   }
 }
 
@@ -443,7 +443,7 @@
   .dark[data-theme="new"] body {
     background-image:
       linear-gradient(rgba(13,12,18,0.96), rgba(13,12,18,0.96)),
-      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1920/v1777959000/ghostly_-_Copy_m9e4s7.png');
+      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1920/v1777966115/000040_zydduo.png');
   }
 }
 
@@ -457,7 +457,7 @@ html[data-theme="new"]:not(.dark) main {
 html[data-theme="new"]:not(.dark) body {
   background-image:
     linear-gradient(rgba(240,237,228,0.93), rgba(240,237,228,0.93)),
-    url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_800/v1777959000/ghostly_-_Copy_m9e4s7.png');
+    url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_800/v1777966115/000040_zydduo.png');
   background-size: cover;
   background-repeat: no-repeat;
 }
@@ -466,7 +466,7 @@ html[data-theme="new"]:not(.dark) body {
   html[data-theme="new"]:not(.dark) body {
     background-image:
       linear-gradient(rgba(240,237,228,0.93), rgba(240,237,228,0.93)),
-      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1280/v1777959000/ghostly_-_Copy_m9e4s7.png');
+      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1280/v1777966115/000040_zydduo.png');
   }
 }
 
@@ -474,7 +474,7 @@ html[data-theme="new"]:not(.dark) body {
   html[data-theme="new"]:not(.dark) body {
     background-image:
       linear-gradient(rgba(240,237,228,0.93), rgba(240,237,228,0.93)),
-      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1920/v1777959000/ghostly_-_Copy_m9e4s7.png');
+      url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1920/v1777966115/000040_zydduo.png');
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -845,29 +845,6 @@ html[data-theme="new"]:not(.dark) .data-table tbody tr:hover td[data-column="nam
   color: var(--color-text);
 }
 
-/* ─── Spirit Theme: Larger Card Images in Table ─────────────────────────── */
-/* Increase image size for better visual identification */
-[data-theme="new"] .data-table td[data-column="image"] img {
-  width: 64px;
-  height: 64px;
-  min-width: 64px;
-}
-
-/* Adjust row height to accommodate larger images */
-[data-theme="new"] .data-table tbody td[data-column="image"] {
-  padding-top: 8px;
-  padding-bottom: 8px;
-}
-
-/* Mobile: ensure images don't overflow */
-@media (max-width: 640px) {
-  [data-theme="new"] .data-table td[data-column="image"] img {
-    width: 56px;
-    height: 56px;
-    min-width: 56px;
-  }
-}
-
 
 
 /* ─── Card Detail Page — Spirit Theme ─────────────────────────────────────── */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -156,9 +156,9 @@
   /* Spirit Scroll theme — ink on washi (light mode) */
   html[data-theme="new"]:not(.dark) {
     --color-bg: #F0EDE4;
-    --color-surface: #F7F4EE;
+    --color-surface: #F9F6F0;
     --color-header: #E8E3D8;
-    --color-text: #1A1614;
+    --color-text: #2b2013;
     --color-text-secondary: #5C5249;
     --color-accent: #3D5C5A;
     --color-accent-hover: #2D4A48;
@@ -425,7 +425,7 @@
    Opacity is controlled by the dark gradient on top: alpha = 1 - desired_image_opacity */
 .dark[data-theme="new"] body {
   background-image:
-    linear-gradient(rgba(13,12,18,0.96), rgba(13,12,18,0.96)),
+    linear-gradient(rgba(13,12,18,0.80), rgba(13,12,18,0.80)),
     url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_800/v1777966115/000040_zydduo.png');
   background-size: cover;
   background-repeat: no-repeat;
@@ -434,7 +434,7 @@
 @media (min-width: 1024px) {
   .dark[data-theme="new"] body {
     background-image:
-      linear-gradient(rgba(13,12,18,0.96), rgba(13,12,18,0.96)),
+      linear-gradient(rgba(13,12,18,0.80), rgba(13,12,18,0.80)),
       url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1280/v1777966115/000040_zydduo.png');
   }
 }
@@ -442,7 +442,7 @@
 @media (min-width: 1680px) {
   .dark[data-theme="new"] body {
     background-image:
-      linear-gradient(rgba(13,12,18,0.96), rgba(13,12,18,0.96)),
+      linear-gradient(rgba(13,12,18,0.80), rgba(13,12,18,0.80)),
       url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1920/v1777966115/000040_zydduo.png');
   }
 }
@@ -456,7 +456,7 @@ html[data-theme="new"]:not(.dark) main {
 /* Ghostly mist overlay — light spirit mode, parchment tint over the same image */
 html[data-theme="new"]:not(.dark) body {
   background-image:
-    linear-gradient(rgba(240,237,228,0.93), rgba(240,237,228,0.93)),
+    linear-gradient(rgba(240,237,228,0.70), rgba(240,237,228,0.70)),
     url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_800/v1777966115/000040_zydduo.png');
   background-size: cover;
   background-repeat: no-repeat;
@@ -465,7 +465,7 @@ html[data-theme="new"]:not(.dark) body {
 @media (min-width: 1024px) {
   html[data-theme="new"]:not(.dark) body {
     background-image:
-      linear-gradient(rgba(240,237,228,0.93), rgba(240,237,228,0.93)),
+      linear-gradient(rgba(240,237,228,0.70), rgba(240,237,228,0.70)),
       url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1280/v1777966115/000040_zydduo.png');
   }
 }
@@ -473,7 +473,7 @@ html[data-theme="new"]:not(.dark) body {
 @media (min-width: 1680px) {
   html[data-theme="new"]:not(.dark) body {
     background-image:
-      linear-gradient(rgba(240,237,228,0.93), rgba(240,237,228,0.93)),
+      linear-gradient(rgba(240,237,228,0.70), rgba(240,237,228,0.70)),
       url('https://res.cloudinary.com/dn3j8sqcc/image/upload/f_auto,q_auto:low,w_1920/v1777966115/000040_zydduo.png');
   }
 }
@@ -800,16 +800,57 @@ html[data-theme="new"]:not(.dark) .data-table tbody tr:hover td[data-column="nam
   animation: respiration 5s ease-in-out infinite;
 }
 
+/* Popup skill/ability descriptions: use full theme text color in spirit mode */
+[data-theme="new"] .popup .text-secondary {
+  color: var(--color-text);
+}
+
+
+
+/* ─── Card Detail Page — Spirit Theme ─────────────────────────────────────── */
+
+/* 1. Ability & skill descriptions: full text color, not dimmed secondary */
+[data-theme="new"] [data-i18n="skill-description"],
+[data-theme="new"] [data-i18n="ability-description"] {
+  color: var(--color-text);
+}
+
+/* 2. Rarity stars: match table treatment */
+.dark[data-theme="new"] [data-attribute] img[alt="★"] {
+  filter: drop-shadow(0 0 4px rgba(255, 200, 80, 0.65)) drop-shadow(1px 1px 2px rgba(0,0,0,0.5));
+}
+html[data-theme="new"]:not(.dark) [data-attribute] img[alt="★"] {
+  filter: hue-rotate(-20deg) saturate(0.9) brightness(0.62) drop-shadow(0 0 1px rgba(0,0,0,0.4));
+}
+
+/* 3. Availability pills — ghost outline in light spirit mode */
+html[data-theme="new"]:not(.dark) [data-section="availability"] span[class*="bg-purple-500"],
+html[data-theme="new"]:not(.dark) [data-section="availability"] span[class*="bg-yellow-500"],
+html[data-theme="new"]:not(.dark) [data-section="availability"] span[class*="bg-blue-500"],
+html[data-theme="new"]:not(.dark) [data-section="availability"] span[class*="bg-green-500"],
+html[data-theme="new"]:not(.dark) [data-section="availability"] span[class*="bg-cyan-500"] {
+  background-color: transparent !important;
+  border: 1px solid currentColor;
+}
+
+/* 4. Skill & ability tags — ghost outline on parchment */
+html[data-theme="new"]:not(.dark) [data-attribute] span[class*="bg-sky-100"],
+html[data-theme="new"]:not(.dark) [data-attribute] span[class*="bg-amber-100"] {
+  background-color: transparent !important;
+  border: 1px solid currentColor;
+}
+
+
 /* ─── Keyword Highlight Colours — disabled, spans present but unstyled ──────── */
 
 /* ─── Light Spirit Mode Contrast Fixes ────────────────────────────────────── */
 
-/* 1. Rarity stars: deepen gold + anchoring shadow so they read on parchment */
+/* 1. Rarity stars: tarnished gold — shift hue toward amber, deepen brightness */
 html[data-theme="new"]:not(.dark) .data-table tbody td[data-column="rarity"] img {
-  filter: saturate(1.2) brightness(0.78) drop-shadow(0 0 1px rgba(0, 0, 0, 0.45));
+  filter: hue-rotate(-20deg) saturate(0.9) brightness(0.62) drop-shadow(0 0 1px rgba(0, 0, 0, 0.4));
 }
 
-/* 2. Badge emboss: lighter shadows suit the pale parchment surface */
+/* 2. Badge emboss: lighter inset shadows suit parchment surface */
 html[data-theme="new"]:not(.dark) .badge {
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.18),
@@ -817,7 +858,7 @@ html[data-theme="new"]:not(.dark) .badge {
     inset -1px -1px 2px rgba(255, 255, 255, 0.55);
 }
 
-/* 3. Table headers: deep sepia ink instead of light secondary */
+/* 3. Table headers: deep sepia ink */
 html[data-theme="new"]:not(.dark) .data-table thead th {
   color: #3A2E24;
 }
@@ -832,7 +873,24 @@ html[data-theme="new"]:not(.dark) .data-table tbody tr:hover td {
   background-color: rgba(0, 0, 0, 0.025);
 }
 
-/* 6. Source/acquisition tag pills: add a faint border to separate from parchment */
+/* 6. Source pills — ghost outline: transparent bg, colored border + text (stamped seal) */
 html[data-theme="new"]:not(.dark) .data-table td[data-column="sources"] span {
-  border: 1px solid rgba(0, 0, 0, 0.18);
+  background-color: transparent !important;
+  border: 1px solid currentColor;
+}
+
+/* 7. Bond type colors — ukiyo-e palette: shrine red / deep indigo / forest green */
+html[data-theme="new"]:not(.dark) .data-table td[data-column="bonds"] .text-red-600 {
+  color: #c2410c;
+}
+html[data-theme="new"]:not(.dark) .data-table td[data-column="bonds"] .text-blue-600 {
+  color: #1e3a8a;
+}
+html[data-theme="new"]:not(.dark) .data-table td[data-column="bonds"] .text-green-600 {
+  color: #15803d;
+}
+
+/* 8. Card container: explicitly solid so texture doesn't bleed through */
+html[data-theme="new"]:not(.dark) .card {
+  background-color: #F9F6F0;
 }


### PR DESCRIPTION
- New Spirit Scroll theme (data-theme="new") with:
  - Dark mode: ink brush aesthetics with misty overlays and breathing animations
  - Light mode: ink-on-washi parchment palette
  - Custom styling for tables, nav links, badges, and game icons
- Theme toggle in header showing active theme (click to switch)
- Theme persistence via localStorage (otogidb-style-variant)
- Enlarged card images in table view for better visual identification
- UI/UX improvements for readability and screenshot capability
- Maintenance notice updated to announce the new theme release
- Highlight skill text improvements in highlightSkillText.tsx